### PR TITLE
[ISSUE-80] 관리자모드 언론사 이름변경 오류 수정

### DIFF
--- a/src/main/java/com/antybeety/press/model/dao/PressDAO.java
+++ b/src/main/java/com/antybeety/press/model/dao/PressDAO.java
@@ -59,14 +59,16 @@ public class PressDAO {
         return result;
     }
     public int updatePressName(String code, String name){
-        //중복체크
-        if((searchPressName(code)!=null)){
+        //중복체크( null이 아니고, 코드로 검색해서 가져온 이름이 바꾸려는 이름과 일치할 경우(바꾸려는이름과 현재 이름이  -1 리턴))
+        String checkName=searchPressName(code);
+        if((checkName!=null)&&(checkName.equals(name))){
             return -1;
         }
         PressMapper mapper = getMapper();
         HashMap<String, Object> param = new HashMap<String, Object>();
         param.put("code", code);
         param.put("name", name);
+
         return mapper.updatePressName(param);
     }
 }

--- a/src/test/java/com/antybeety/press/model/dao/PressDAOTest.java
+++ b/src/test/java/com/antybeety/press/model/dao/PressDAOTest.java
@@ -90,10 +90,12 @@ public class PressDAOTest {
     @Test
     public void test_코드로언론사이름변경(){
         String code="TS";
-        assertNotNull("언론사명변경",dao.updatePressName(code,"테스팅"));
+       int result= dao.updatePressName(code,"토토뉴스");
+        assertNotNull("언론사명변경",result);
+        System.out.println(result);
         System.out.println(dao.searchAllNames());
-        System.out.println("중복이면 -1이 출력됩니다 : " + dao.updatePressName(code,"테스팅"));
-        assertNotNull("안론사명재변경",dao.updatePressName(code,"테스트 뉴스"));
-        System.out.println(dao.searchAllNames());
+      //  System.out.println("중복이면 -1이 출력됩니다 : " + dao.updatePressName(code,"테스팅"));
+       // assertNotNull("안론사명재변경",dao.updatePressName(code,"테스트 뉴스"));
+       // System.out.println(dao.searchAllNames());
     }
 }


### PR DESCRIPTION
   중복체크방법 : 입력받은 코드로 현재 존재하는 기사이름이 존재하는지 체크
   ( null이 아니고, 코드로 검색해서 가져온 이름이 바꾸려는 이름과 일치할 경우
(바꾸려는이름과 현재 이름이 같을경우 -1 리턴)