### PR TITLE
[ISSUE-400] admin map에서 edge를 클릭할 때 원래 정보 받아오는 UI

### DIFF
--- a/web/resources/js/adminMap.js
+++ b/web/resources/js/adminMap.js
@@ -1153,10 +1153,32 @@ function openEdgeInfo(edge) {
 			edgeInfoOverlay.setPosition(nowEdgePoint);
 
 			tempEdgeIndex = findEdgeIndex(edge);
+			settingEdgeInfo(edgeIndex);
 
 			edgeInfoOverlay.setMap(map);
 		}
 	}
+}
+
+function settingEdgeInfo(edgeIndex){
+	var edgeId = edgeIdArray[edgeIndex];
+
+	$.ajax('api/map/way/getEdgeInfo',{
+		type:'GET',
+		data: {
+			edgeId: edgeIdArray[edgeIndex]
+		}
+	}).then(function(data,status){
+		if(status=='success'){
+			var tLandType = data.landType;
+			var tRoadType = data.roadType;
+			var tSafetyScore = data.safetyScore;
+
+			$('input:radio[name="chk_landType"]:input[value='+tLandType+']').attr("checked",true);
+			$('input:radio[name="chk_roadType"]:input[value='+tRoadType+']').attr("checked",true);
+			$("#safetyScore").val(tSafetyScore);
+		}
+	});
 }
 
 function findEdgeIndex(edge){

--- a/web/resources/js/adminMap.js
+++ b/web/resources/js/adminMap.js
@@ -1166,7 +1166,7 @@ function settingEdgeInfo(edgeIndex){
 	$.ajax('api/map/way/getEdgeInfo',{
 		type:'GET',
 		data: {
-			edgeId: edgeIdArray[edgeIndex]
+			edgeId: edgeId
 		}
 	}).then(function(data,status){
 		if(status=='success'){


### PR DESCRIPTION
edge index를 파라미터로 받아 해당하는 엣지 정보를 edgeInfoContent에 세팅하는 메서드 구현
    1. edgeIdArray[edgeIndex] 를 통해 edge의 id를 구함
    2. ajax요청을 통해 landType, safetyScore, roadType 을 리턴받음
    3. 세 값을 통해 edgeInfoContent의 지역분류, 안전수치, 대로분류의 값을 세팅함